### PR TITLE
Add GranaryCameraFeeder as clone of GranaryFeeder

### DIFF
--- a/custom_components/petlibro/devices/__init__.py
+++ b/custom_components/petlibro/devices/__init__.py
@@ -1,7 +1,9 @@
 from typing import Dict, Type
 from .device import Device
 from .feeders.granary_feeder import GranaryFeeder
+from .feeders.granary_camera_feeder import GranaryCameraFeeder
 
 product_name_map : Dict[str, Type[Device]] = {
-    "Granary Feeder": GranaryFeeder
+    "Granary Feeder": GranaryFeeder,
+    "Granary Camera Feeder": GranaryCameraFeeder
 }

--- a/custom_components/petlibro/devices/feeders/granary_camera_feeder.py
+++ b/custom_components/petlibro/devices/feeders/granary_camera_feeder.py
@@ -1,0 +1,4 @@
+from .granary_feeder import GranaryFeeder
+
+class GranaryCameraFeeder(GranaryFeeder):
+  pass


### PR DESCRIPTION
This is so small, but it adds the camera feeder (without camera support) as a clone of the GranaryFeeder. This way both can be developed in parallel and people with the camera model can contribute easier. I tested this on my instance and it worked for the same fields supported by the GranaryFeeder.