### PR TITLE
Add `Smart` to all Granary Feeders names

### DIFF
--- a/custom_components/petlibro/__init__.py
+++ b/custom_components/petlibro/__init__.py
@@ -7,7 +7,7 @@ from homeassistant.helpers.device_registry import DeviceEntry
 from custom_components.petlibro.devices.feeders.feeder import Feeder
 
 from .devices import Device
-from .devices.feeders.granary_feeder import GranaryFeeder
+from .devices.feeders.granary_smart_feeder import GranarySmartFeeder
 from .const import DOMAIN
 from .hub import PetLibroHub
 
@@ -17,7 +17,7 @@ PLATFORMS_BY_TYPE = {
     Feeder: (
         Platform.SWITCH,
     ),
-    GranaryFeeder: (
+    GranarySmartFeeder: (
         Platform.SENSOR,
     ),
 }

--- a/custom_components/petlibro/devices/__init__.py
+++ b/custom_components/petlibro/devices/__init__.py
@@ -1,9 +1,9 @@
 from typing import Dict, Type
 from .device import Device
-from .feeders.granary_feeder import GranaryFeeder
-from .feeders.granary_camera_feeder import GranaryCameraFeeder
+from .feeders.granary_smart_feeder import GranarySmartFeeder
+from .feeders.granary_smart_camera_feeder import GranarySmartCameraFeeder
 
 product_name_map : Dict[str, Type[Device]] = {
-    "Granary Feeder": GranaryFeeder,
-    "Granary Camera Feeder": GranaryCameraFeeder
+    "Granary Smart Feeder": GranarySmartFeeder,
+    "Granary Smart Camera Feeder": GranarySmartCameraFeeder
 }

--- a/custom_components/petlibro/devices/feeders/granary_camera_feeder.py
+++ b/custom_components/petlibro/devices/feeders/granary_camera_feeder.py
@@ -1,4 +1,0 @@
-from .granary_feeder import GranaryFeeder
-
-class GranaryCameraFeeder(GranaryFeeder):
-  pass

--- a/custom_components/petlibro/devices/feeders/granary_smart_camera_feeder.py
+++ b/custom_components/petlibro/devices/feeders/granary_smart_camera_feeder.py
@@ -1,0 +1,4 @@
+from .granary_smart_feeder import GranarySmartFeeder
+
+class GranarySmartCameraFeeder(GranarySmartFeeder):
+  pass

--- a/custom_components/petlibro/devices/feeders/granary_smart_feeder.py
+++ b/custom_components/petlibro/devices/feeders/granary_smart_feeder.py
@@ -3,7 +3,7 @@ from typing import cast
 from .feeder import Feeder
 
 
-class GranaryFeeder(Feeder):
+class GranarySmartFeeder(Feeder):
     async def refresh(self):
         await super().refresh()
         self.update_data({

--- a/custom_components/petlibro/sensor.py
+++ b/custom_components/petlibro/sensor.py
@@ -18,7 +18,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .devices import Device
 from .devices.feeders.feeder import Feeder
-from .devices.feeders.granary_feeder import GranaryFeeder
+from .devices.feeders.granary_smart_feeder import GranarySmartFeeder
 from . import PetLibroHubConfigEntry
 from .entity import PetLibroEntity, _DeviceT, PetLibroEntityDescription
 
@@ -95,13 +95,13 @@ class PetLibroSensorEntity(PetLibroEntity[_DeviceT], SensorEntity):  # type: ign
 
 
 DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
-    GranaryFeeder: [
-        PetLibroSensorEntityDescription[GranaryFeeder](
+    GranarySmartFeeder: [
+        PetLibroSensorEntityDescription[GranarySmartFeeder](
             key="remaining_desiccant",
             translation_key="remaining_desiccant",
             icon="mdi:package"
         ),
-        PetLibroSensorEntityDescription[GranaryFeeder](
+        PetLibroSensorEntityDescription[GranarySmartFeeder](
             key="today_feeding_quantity",
             translation_key="today_feeding_quantity",
             icon="mdi:scale",
@@ -109,7 +109,7 @@ DEVICE_SENSOR_MAP: dict[type[Device], list[PetLibroSensorEntityDescription]] = {
             device_class_fn=device_class_feeder,
             state_class=SensorStateClass.TOTAL_INCREASING
         ),
-        PetLibroSensorEntityDescription[GranaryFeeder](
+        PetLibroSensorEntityDescription[GranarySmartFeeder](
             key="today_feeding_times",
             translation_key="today_feeding_times",
             icon="mdi:history",


### PR DESCRIPTION
The Feeders all use the word "Smart" in the name now. This fixes both feeders (Camera and No Camera). I verified this worked with my feeder. 